### PR TITLE
Add CORS middleware to API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata"; 
 import express from 'express';
+import cors from 'cors';
 import { AppDataSource } from './data-source';
 import { criarLivro, listarLivros, atualizarLivro } from './controllers/livroController';
 import { listarUsuarios, obterUsuario, atualizarUsuario, deletarUsuario } from './controllers/usuarioController';
@@ -11,6 +12,7 @@ import { criarCategoria, listarCategorias, atualizarCategoria, deletarCategoria 
 
 const app: express.Application = express();
 app.use(express.json());
+app.use(cors());
 
 interface Params {
     id: string;


### PR DESCRIPTION
## Summary
- enable CORS in the API server

## Testing
- `npx tsc src/index.ts --noEmit` *(fails: Unable to resolve signature of property decorator)*

------
https://chatgpt.com/codex/tasks/task_e_686db4e212e883249fd4d1be10bb7cc8