### PR TITLE
Add single book fetch endpoint and update form

### DIFF
--- a/frontend/src/BookForm.tsx
+++ b/frontend/src/BookForm.tsx
@@ -16,10 +16,9 @@ export function BookForm() {
 
   useEffect(() => {
     if (isEdit) {
-      fetch(`http://localhost:3000/livros`)
+      fetch(`http://localhost:3000/livros/${id}`)
         .then(res => res.json())
-        .then((data) => {
-          const livro = data.find((l: any) => l.id === Number(id));
+        .then((livro) => {
           if (livro) {
             setForm({ titulo: livro.titulo, autor: livro.autor });
           }

--- a/src/controllers/livroController.ts
+++ b/src/controllers/livroController.ts
@@ -47,6 +47,28 @@ export const listarLivros = async (req: Request, res: Response) => {
     }
 };
 
+export const obterLivro = async (req: Request<Params>, res: Response) => {
+    const id = parseInt(req.params.id);
+
+    try {
+        const livro = await livroRepository.findOne({
+            where: { id },
+            relations: ["categorias"]
+        });
+
+        if (!livro) {
+            return res.status(404).json({ error: "Livro não encontrado" });
+        }
+
+        return res.status(200).json({
+            ...livro,
+            categorias: livro.categorias.map(c => ({ id: c.id, nome: c.nome }))
+        });
+    } catch (error) {
+        res.status(500).json({ error: "Erro ao buscar livro" });
+    }
+};
+
 export const atualizarLivro = async (req: Request<Params>, res: Response) => {
     const id = parseInt(req.params.id);
     const { titulo, categorias } = req.body;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import express from 'express';
 import cors from 'cors';
 import { AppDataSource } from './data-source';
-import { criarLivro, listarLivros, atualizarLivro, deletarLivro } from './controllers/livroController';
+import { criarLivro, listarLivros, obterLivro, atualizarLivro, deletarLivro } from './controllers/livroController';
 import { listarUsuarios, obterUsuario, atualizarUsuario, deletarUsuario } from './controllers/usuarioController';
 import { criarEmprestimo, concluirDevolucao, listarEmprestimos } from './controllers/emprestimoController';
 import { RequestHandler } from 'express';
@@ -29,6 +29,7 @@ app.delete("/usuarios/:id", deletarUsuario as RequestHandler<Params>);
 // Rotas de livros
 app.post("/livros", criarLivro);
 app.get("/livros", listarLivros);
+app.get("/livros/:id", obterLivro as RequestHandler<Params>);
 app.put("/livros/:id", atualizarLivro as RequestHandler<Params>);
 app.delete("/livros/:id", deletarLivro as RequestHandler<Params>);
 
@@ -45,5 +46,4 @@ app.get("/emprestimos", listarEmprestimos);
 AppDataSource.initialize()
     .then(() => {
         console.log("Banco de dados conectado!");
-        app.listen(3000, () => console.log("Servidor rodando na porta 3000"));
-    })    .catch((err) => console.error("Erro na conexão:", err));
+        app.listen(3000, () => console.log("Servidor rodando na porta 3000"));    })    .catch((err) => console.error("Erro na conexão:", err));


### PR DESCRIPTION
## Summary
- implement `obterLivro` controller to get a single book
- expose new route in API
- fetch `/livros/:id` in `BookForm` when editing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json` *(fails: Could not find a declaration file for module 'cors')*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686ec2f3121c832497d922c9bfb8bba9